### PR TITLE
Render stroke in ScribblePainter using perfect_freehand

### DIFF
--- a/lib/src/scribble_painter.dart
+++ b/lib/src/scribble_painter.dart
@@ -3,10 +3,8 @@ import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
+import 'package:perfect_freehand/perfect_freehand.dart' as pf;
 import 'package:scribble/scribble.dart';
-import 'package:vector_math/vector_math.dart';
-
-const double _maxDistanceToDrawPoint = kPrecisePointerPanSlop * 1;
 
 class ScribblePainter extends CustomPainter {
   ScribblePainter({
@@ -35,28 +33,27 @@ class ScribblePainter extends CustomPainter {
     for (int i = 0; i < lines.length; ++i) {
       final line = lines[i];
       paint.color = Color(lines[i].color);
-      if (line.points.isNotEmpty) {
-        final p = line.points.first;
-        final distance = (line.points.length == 1)
-            ? 0
-            : (line.points[1].asOffset - p.asOffset).distance;
-        if (distance <= _maxDistanceToDrawPoint) {
-          canvas.drawCircle(
-              p.asOffset, _getWidth(line.width, p.pressure, 0), paint);
-        }
-
-        if (line.points.length > 1) {
-          final p2 = line.points.last;
-          final p1 = line.points[line.points.length - 2];
-          final distance = (p2.asOffset - p1.asOffset).distance;
-          if (distance <= _maxDistanceToDrawPoint) {
-            canvas.drawCircle(p2.asOffset,
-                _getWidth(line.width, p2.pressure, distance), paint);
-          }
+      final points = line.points.map((point) =>
+          pf.Point(point.x, point.y, point.pressure)).toList();
+      final outlinePoints = pf.getStroke(points, size: line.width * 2);
+      final path = Path();
+      if (outlinePoints.isEmpty) {
+        continue;
+      } else if (outlinePoints.length < 2) {
+        path.addOval(Rect.fromCircle(
+            center: Offset(outlinePoints[0].x, outlinePoints[0].y),
+            radius: 1));
+      } else {
+        path.moveTo(outlinePoints[0].x, outlinePoints[0].y);
+        for (int i = 1; i < outlinePoints.length - 1; ++i) {
+          final p0 = outlinePoints[i];
+          final p1 = outlinePoints[i + 1];
+          path.quadraticBezierTo(
+              p0.x, p0.y, (p0.x + p1.x) / 2, (p0.y + p1.y) / 2);
         }
       }
-      Vertices path = _getVerticesForLine(line);
-      canvas.drawVertices(path, BlendMode.dst, paint);
+      paint.color = Color(lines[i].color);
+      canvas.drawPath(path, paint);
     }
     if (state.pointerPosition != null &&
         (state is Drawing && drawPointer || state is Erasing && drawEraser)) {
@@ -80,38 +77,6 @@ class ScribblePainter extends CustomPainter {
     }
   }
 
-  Vertices _getVerticesForLine(SketchLine line) {
-    List<Offset> positions = [];
-
-    for (int i = 0; i < line.points.length; i++) {
-      final current = line.points[i];
-      final prev = i == 0 ? current : line.points[i - 1];
-      final next = i == line.points.length - 1 ? current : line.points[i + 1];
-      final offset = _getOffset(prev.asOffset, current.asOffset, next.asOffset);
-      final distance = (current.asOffset - prev.asOffset).distance +
-          (next.asOffset - current.asOffset).distance;
-      if (i == 0) {
-        positions.add(current.asOffset);
-        positions.add(current.asOffset);
-      } else if (i == line.points.length - 1) {
-        positions.add(current.asOffset);
-        positions.add(current.asOffset);
-      } else {
-        final width = _getWidth(line.width, current.pressure, distance);
-        final p1 = current.asOffset + offset * width;
-        final p2 = current.asOffset - offset * width;
-        positions.insert(positions.length - 1, p1);
-        positions.add(p2);
-        positions.add(p1);
-        positions.add(p2);
-      }
-    }
-    return Vertices(
-      VertexMode.triangleStrip,
-      positions,
-    );
-  }
-
   double _getWidth(double baseWidth, double pressure, double distance) {
     final speed = distance / (1000 / 60);
     final pressureInfluence = pressure * baseWidth * 2 * pressureFactor -
@@ -119,16 +84,6 @@ class ScribblePainter extends CustomPainter {
 
     final speedInfluence = -baseWidth * speed * speedFactor;
     return max(baseWidth + pressureInfluence + speedInfluence, baseWidth * minWidthFactor);
-  }
-
-  Offset _getOffset(Offset prev, Offset current, Offset next) {
-    final o1 = prev - current;
-    final v1 = Vector2(o1.dx, o1.dy);
-    final o2 = next - current;
-    final v2 = Vector2(o2.dx, o2.dy);
-    final a = v1.angleTo(v2) * .5;
-    final res = Matrix2.rotation(a).transform(v1).normalized();
-    return Offset(res.x, res.y);
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,6 +361,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.1"
+  perfect_freehand:
+    dependency: "direct main"
+    description:
+      name: perfect_freehand
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   pool:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   history_state_notifier: ^0.0.5
   state_notifier: ^0.7.2+1
   vector_math: ^2.1.1
+  perfect_freehand: ^1.0.4
 
 dev_dependencies:
   build_runner: ^2.1.8


### PR DESCRIPTION
As per issue https://github.com/fyzio/scribble/issues/19, this integrates `perfect_freehand` to render strokes, pretty much just lifting the `CustomerPainter` recipe straight from the [perfect_freehand docs](https://pub.dev/packages/perfect_freehand#rendering). Example difference in rendering:

## Before
<img width="571" alt="current" src="https://user-images.githubusercontent.com/45822724/170056144-161f1b15-e293-45cd-94f2-99201071c9fd.png">

## After
<img width="571" alt="with-perfect-freehand" src="https://user-images.githubusercontent.com/45822724/170056155-34977da7-575c-439e-b396-09f87f0dcfeb.png">

