### PR TITLE
add `allowedPointersMode` to `setEraser` and `setColor`

### DIFF
--- a/lib/src/scribble.notifier.dart
+++ b/lib/src/scribble.notifier.dart
@@ -169,6 +169,7 @@ class ScribbleNotifier extends ScribbleNotifierBase
       sketch: state.sketch,
       selectedWidth: state.selectedWidth,
       scaleFactor: state.scaleFactor,
+      allowedPointersMode: state.allowedPointersMode,
       activePointerIds: state.activePointerIds,
     );
   }
@@ -198,11 +199,13 @@ class ScribbleNotifier extends ScribbleNotifierBase
         sketch: s.sketch,
         selectedColor: color.value,
         selectedWidth: s.selectedWidth,
+        allowedPointersMode: s.allowedPointersMode,
       ),
       erasing: (s) => ScribbleState.drawing(
         sketch: s.sketch,
         selectedColor: color.value,
         selectedWidth: s.selectedWidth,
+        allowedPointersMode: s.allowedPointersMode,
         scaleFactor: state.scaleFactor,
         activePointerIds: state.activePointerIds,
       ),


### PR DESCRIPTION
Bug: When `setEraser` and `setColor` is called, `allowedPointersMode` will reset to default value `ScribblePointerMode.all`.
Fix the situation like: `allowedPointersMode` is set to `ScribblePointerMode.penOnly` on `ScribbleNotifier` first, but mouse and touch will be allowed after change pen color or switch to eraser mode.
